### PR TITLE
增加了 if os.path.exists(lp_src): 判断。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ✨ 魔法少女工坊 (Magical Girl Workshop) - NAS Edition
+# ✨ 魔法少女工坊 (Magical Girl Workshop) - Windows Edition
 
 ![Version](https://img.shields.io/badge/version-1.2.2-FB7299?style=for-the-badge&logo=bilibili&logoColor=white)
 ![Built with Gemini](https://img.shields.io/badge/Built%20with-Gemini-8E75B2?style=for-the-badge&logo=googlegemini&logoColor=white)
@@ -166,4 +166,5 @@
 
 
 Copyright © 2026 泠萌404
+
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-# ✨ Magical Girl Workshop - NAS Edition
+# ✨ Magical Girl Workshop - Windows Edition
 
 ![Version](https://img.shields.io/badge/version-1.2.2-FB7299?style=for-the-badge&logo=bilibili&logoColor=white)
 ![Built with Gemini](https://img.shields.io/badge/Built%20with-Gemini-8E75B2?style=for-the-badge&logo=googlegemini&logoColor=white)
@@ -166,6 +166,7 @@ This project is licensed under the GPL-3.0 Open Source License.
 
 
 Copyright © 2026 LingMoe404
+
 
 
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,4 +1,4 @@
-# ✨ 魔法少女工房 (Magical Girl Workshop) - NAS Edition
+# ✨ 魔法少女工房 (Magical Girl Workshop) - Windows Edition
 
 ![Version](https://img.shields.io/badge/version-1.2.2-FB7299?style=for-the-badge&logo=bilibili&logoColor=white)
 ![Built with Gemini](https://img.shields.io/badge/Built%20with-Gemini-8E75B2?style=for-the-badge&logo=googlegemini&logoColor=white)
@@ -166,5 +166,6 @@ Python開発に慣れている場合は、ソースコードから実行でき�
 
 
 Copyright © 2026 LingMoe404
+
 
 

--- a/workers/encoder.py
+++ b/workers/encoder.py
@@ -464,8 +464,11 @@ class EncoderWorker(BaseWorker):
                                 try:
                                     if abs_src == abs_dest:
                                         bak_path = lp_src + ".bak"
-                                        if os.path.exists(bak_path): os.remove(bak_path)
-                                        os.replace(lp_src, bak_path)
+                                        # [Fix] 增强重试逻辑：仅当源文件存在时才执行重命名（防止重试时因源文件已更名而报错）
+                                        if os.path.exists(lp_src):
+                                            if os.path.exists(bak_path): os.remove(bak_path)
+                                            os.replace(lp_src, bak_path)
+                                        
                                         shutil.move(lp_temp, lp_dest)
                                         if os.path.exists(bak_path): os.remove(bak_path)
                                     else:


### PR DESCRIPTION
正常情况：第一次执行时源文件存在，正常重命名为 .bak，然后移动新文件。 异常重试：如果第一次重命名成功了，但移动新文件失败（比如被杀毒软件拦截），程序进入第二次重试。此时源文件已经变成了 .bak，lp_src 不存在了。原代码会因为找不到源文件而报错退出；修改后的代码会跳过重命名步骤，直接再次尝试移动新文件，从而提高了成功的概率。